### PR TITLE
Handle -c < 100 (e.g. only show me last 10 challenges)

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -33,6 +33,10 @@ def load_challenges(haddr, numchalls=500, cursor=None):
         if not cursor:
             break
 
+    if len(chals) > numchalls:
+        print(f"truncating challenges from {len(chals)} to {numchalls}")
+        chals = chals[:numchalls]
+
     return chals
 
 


### PR DESCRIPTION
Sometimes I'm just interested in fewer than 100 challenges, particularly for low-activity hotspots.

Please forgive my rusty python
