### PR TITLE
Compile and compare results of new "is_valid" field

### DIFF
--- a/analyze_hotspot.py
+++ b/analyze_hotspot.py
@@ -92,8 +92,8 @@ def pocv10_violations(hotspot, chals):
     H = Hotspots()
     haddr = hotspot['address']
     hlat, hlng = hotspot['lat'], hotspot['lng']
-    transmits_w = dict(total=0, bad_rssi=0, bad_snr=0, not_valid=0)
-    receives_w = dict(total=0, bad_rssi=0, bad_snr=0, not_valid=0)
+    transmits_w = dict(total=0, bad_rssi=0, bad_snr=0, is_valid_present=0, not_valid=0)
+    receives_w = dict(total=0, bad_rssi=0, bad_snr=0, is_valid_present=0, not_valid=0)
     poc_rcv = dict(total=0, bad_rssi=0, bad_snr=0)
     bad_neighbors = dict()
 
@@ -120,10 +120,10 @@ def pocv10_violations(hotspot, chals):
                     if w['signal'] < snr_rssi_lim:
                         transmits_w['bad_snr'] += 1
                         bad_neighbors[w['gateway']]['snr'] += 1
-                    if not 'is_valid' in w:
-                        print(f"transmits: no is_valid field for {w}")
-                    if 'is_valid' in w and not w['is_valid']:
-                        transmits_w['not_valid'] += 1
+                    if 'is_valid' in w:
+                        transmits_w['is_valid_present'] += 1
+                        if not w['is_valid']:
+                            transmits_w['not_valid'] += 1
 
                 if p['receipt'] and transmitter:
                     dist = utils.haversine_km(
@@ -165,20 +165,20 @@ def pocv10_violations(hotspot, chals):
                     if w['signal'] < snr_rssi_lim:
                         receives_w['bad_snr'] += 1
                         bad_neighbors[p['challengee']]['snr'] += 1
-                    if not 'is_valid' in w:
-                        print(f"receives: no is_valid field for {w}")
-                    if 'is_valid' in w and not w['is_valid']:
-                        receives_w['not_valid'] += 1
+                    if 'is_valid' in w:
+                        receives_w['is_valid_present'] += 1
+                        if not w['is_valid']:
+                            receives_w['not_valid'] += 1
             transmitter = p['challengee']
 
 
     print(f"PoC v10 failures for {hotspot['name']}")
 
     print(F"SUMMARY")
-    print(f"Category                   | Total | bad RSSI (%) | bad SNR (%) | !is_valid (%)")
-    print(f"-------------------------------------------------------------------------------")
-    print(f"Witnesses to hotspot >300m | {transmits_w['total']:5d} | {transmits_w['bad_rssi']:4d} ({transmits_w['bad_rssi']*100/max(1, transmits_w['total']):3.0f}%)  | {transmits_w['bad_snr']:4d} ({transmits_w['bad_snr']*100/max(1, transmits_w['total']):3.0f}%) | {transmits_w['not_valid']:4d} ({transmits_w['not_valid']*100/max(1, transmits_w['total']):3.0f}%) |")
-    print(f"Hotspot witnessing  >300m  | {receives_w['total']:5d} | {receives_w['bad_rssi']:4d} ({receives_w['bad_rssi']*100/max(1, receives_w['total']):3.0f}%)  | {receives_w['bad_snr']:4d} ({receives_w['bad_snr']*100/max(1, receives_w['total']):3.0f}%) | {receives_w['not_valid']:4d} ({receives_w['not_valid']*100/max(1, receives_w['total']):3.0f}%) |")
+    print(f"Category                   | Total | bad RSSI (%) | bad SNR (%) | is_valid_present | not_valid (%)")
+    print(f"--------------------------------------------------------------------------------------------------")
+    print(f"Witnesses to hotspot >300m | {transmits_w['total']:5d} | {transmits_w['bad_rssi']:4d} ({transmits_w['bad_rssi']*100/max(1, transmits_w['total']):3.0f}%)  | {transmits_w['bad_snr']:4d} ({transmits_w['bad_snr']*100/max(1, transmits_w['total']):3.0f}%) | {transmits_w['is_valid_present']:16d} | {transmits_w['not_valid']:4d} ({transmits_w['not_valid']*100/max(1, transmits_w['is_valid_present']):3.0f}%) |")
+    print(f"Hotspot witnessing  >300m  | {receives_w['total']:5d} | {receives_w['bad_rssi']:4d} ({receives_w['bad_rssi']*100/max(1, receives_w['total']):3.0f}%)  | {receives_w['bad_snr']:4d} ({receives_w['bad_snr']*100/max(1, receives_w['total']):3.0f}%) | {receives_w['is_valid_present']:16d} | {receives_w['not_valid']:4d} ({receives_w['not_valid']*100/max(1, receives_w['is_valid_present']):3.0f}%) |")
     print(f"Hotspot PoC receipts       | {poc_rcv['total']:5d} | {poc_rcv['bad_rssi']:4d} ({poc_rcv['bad_rssi']*100/max(1, poc_rcv['total']):3.0f}%)  | {poc_rcv['bad_snr']:4d} ({poc_rcv['bad_snr']*100/max(1, poc_rcv['total']):3.0f}%) |")
 
     print()

--- a/analyze_hotspot.py
+++ b/analyze_hotspot.py
@@ -92,8 +92,8 @@ def pocv10_violations(hotspot, chals):
     H = Hotspots()
     haddr = hotspot['address']
     hlat, hlng = hotspot['lat'], hotspot['lng']
-    transmits_w = dict(total=0, bad_rssi=0, bad_snr=0)
-    receives_w = dict(total=0, bad_rssi=0, bad_snr=0)
+    transmits_w = dict(total=0, bad_rssi=0, bad_snr=0, not_valid=0)
+    receives_w = dict(total=0, bad_rssi=0, bad_snr=0, not_valid=0)
     poc_rcv = dict(total=0, bad_rssi=0, bad_snr=0)
     bad_neighbors = dict()
 
@@ -120,6 +120,11 @@ def pocv10_violations(hotspot, chals):
                     if w['signal'] < snr_rssi_lim:
                         transmits_w['bad_snr'] += 1
                         bad_neighbors[w['gateway']]['snr'] += 1
+                    if not 'is_valid' in w:
+                        print(f"transmits: no is_valid field for {w}")
+                    if 'is_valid' in w and not w['is_valid']:
+                        transmits_w['not_valid'] += 1
+
                 if p['receipt'] and transmitter:
                     dist = utils.haversine_km(
                         hlat, hlng,
@@ -137,6 +142,7 @@ def pocv10_violations(hotspot, chals):
                     if p['receipt']['signal'] < snr_rssi_lim:
                         poc_rcv['bad_snr'] += 1
                         bad_neighbors[transmitter]['snr'] += 1
+
             else:
                 for w in p['witnesses']:
                     if w['gateway'] != haddr:
@@ -159,16 +165,20 @@ def pocv10_violations(hotspot, chals):
                     if w['signal'] < snr_rssi_lim:
                         receives_w['bad_snr'] += 1
                         bad_neighbors[p['challengee']]['snr'] += 1
+                    if not 'is_valid' in w:
+                        print(f"receives: no is_valid field for {w}")
+                    if 'is_valid' in w and not w['is_valid']:
+                        receives_w['not_valid'] += 1
             transmitter = p['challengee']
 
 
     print(f"PoC v10 failures for {hotspot['name']}")
 
     print(F"SUMMARY")
-    print(f"Category                   | Total | bad RSSI (%) | bad SNR (%) |")
-    print(f"-----------------------------------------------------------------")
-    print(f"Witnesses to hotspot >300m | {transmits_w['total']:5d} | {transmits_w['bad_rssi']:4d} ({transmits_w['bad_rssi']*100/max(1, transmits_w['total']):3.0f}%)  | {transmits_w['bad_snr']:4d} ({transmits_w['bad_snr']*100/max(1, transmits_w['total']):3.0f}%) |")
-    print(f"Hotspot witnessing  >300m  | {receives_w['total']:5d} | {receives_w['bad_rssi']:4d} ({receives_w['bad_rssi']*100/max(1, receives_w['total']):3.0f}%)  | {receives_w['bad_snr']:4d} ({receives_w['bad_snr']*100/max(1, receives_w['total']):3.0f}%) |")
+    print(f"Category                   | Total | bad RSSI (%) | bad SNR (%) | !is_valid (%)")
+    print(f"-------------------------------------------------------------------------------")
+    print(f"Witnesses to hotspot >300m | {transmits_w['total']:5d} | {transmits_w['bad_rssi']:4d} ({transmits_w['bad_rssi']*100/max(1, transmits_w['total']):3.0f}%)  | {transmits_w['bad_snr']:4d} ({transmits_w['bad_snr']*100/max(1, transmits_w['total']):3.0f}%) | {transmits_w['not_valid']:4d} ({transmits_w['not_valid']*100/max(1, transmits_w['total']):3.0f}%) |")
+    print(f"Hotspot witnessing  >300m  | {receives_w['total']:5d} | {receives_w['bad_rssi']:4d} ({receives_w['bad_rssi']*100/max(1, receives_w['total']):3.0f}%)  | {receives_w['bad_snr']:4d} ({receives_w['bad_snr']*100/max(1, receives_w['total']):3.0f}%) | {receives_w['not_valid']:4d} ({receives_w['not_valid']*100/max(1, receives_w['total']):3.0f}%) |")
     print(f"Hotspot PoC receipts       | {poc_rcv['total']:5d} | {poc_rcv['bad_rssi']:4d} ({poc_rcv['bad_rssi']*100/max(1, poc_rcv['total']):3.0f}%)  | {poc_rcv['bad_snr']:4d} ({poc_rcv['bad_snr']*100/max(1, poc_rcv['total']):3.0f}%) |")
 
     print()


### PR DESCRIPTION
Comparing results of the bad RSSI/SNR calculations with the new "official" `is_valid` field, which is only partially backfilled. 

This is rough and WIP, but wanted to share in case you or anyone else were looking at this too.

Sample results for the first hotspot I saw in explorer, which looks like it's a big fat location liar:

```
python3 analyze_hotspot.py -n joyful-slate-peacock -x poc_v10 -c 500

analyzing 500 challenges from block 528228-505508 over 14 days, 17 hrs
PoC v10 failures for joyful-slate-peacock
SUMMARY
Category                   | Total | bad RSSI (%) | bad SNR (%) | is_valid_present | not_valid (%)
--------------------------------------------------------------------------------------------------
Witnesses to hotspot >300m |   273 |  263 ( 96%)  |    0 (  0%) |               17 |   16 ( 94%) |
Hotspot witnessing  >300m  |   308 |  283 ( 92%)  |    0 (  0%) |               10 |   10 (100%) |
Hotspot PoC receipts       |     1 |    0 (  0%)  |    0 (  0%) |


BY "BAD" NEIGHBOR
Neighboring Hotspot           | owner | dist km | heading |  bad RSSI (%)  |  bad SNR (%)   |
------------------------------+-------+---------+---------+----------------+----------------|
original-eggplant-squid       | same  |   0.4   | 160  S  |  21/ 38 ( 55%) |   0/ 38 (  0%) |
clean-iris-turkey             | same  |   0.4   | 160  S  |  31/ 45 ( 69%) |   0/ 45 (  0%) |
brisk-steel-beaver            | same  |  19.8   | 330 NW  |  78/ 78 (100%) |   0/ 78 (  0%) |
crazy-coconut-lynx            | rTxRX |  19.8   | 330 NW  |  73/ 73 (100%) |   0/ 73 (  0%) |
docile-admiral-squid          | same  |  19.8   | 330 NW  |  71/ 71 (100%) |   0/ 71 (  0%) |
high-eggplant-troll           | rTxRX |  19.8   | 330 NW  |  58/ 58 (100%) |   0/ 58 (  0%) |
future-carob-parrot           | same  |  19.8   | 330 NW  |  84/ 84 (100%) |   0/ 84 (  0%) |
wide-ruby-platypus            | same  |  19.8   | 330 NW  |  89/ 89 (100%) |   0/ 89 (  0%) |
icy-pewter-capybara           | rTxRX |  19.7   | 330 NW  |  41/ 41 (100%) |   0/ 41 (  0%) |
```