### PR TITLE
use python3.8 explicitly with shebang and +x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ To install simply run
 
     git clone https://github.com/Carniverous19/helium_analysis_tools.git
     
-At time of writing only Python3.7+ is required.
+At time of writing only Python3.8+ is required.
 
 # Tools
 A lot of these tools require a cache of hotspots from Helium's hotspot API.  

--- a/analyze_hotspot.py
+++ b/analyze_hotspot.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3.8
 """
 
 Functions to print information about a specific hotspot

--- a/beacon_reports.py
+++ b/beacon_reports.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3.8
 
 import argparse
 import statistics

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3.8
 import json
 import urllib.request
 import urllib.error


### PR DESCRIPTION
statistics.quantiles was added in version 3.8, so update readme to reflect this
also, add shebang and executable bit on *.py files to be able to use them directly (e.g. `./beacon_reports.py -x beacons -a XXX`